### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/RS485protocol/keywords.txt
+++ b/RS485protocol/keywords.txt
@@ -6,17 +6,17 @@
 # Datatypes (KEYWORD1)
 ###########################################
 
-RS485data_struct KEYWORD1
-RS485protocol    KEYWORD1
+RS485data_struct	KEYWORD1
+RS485protocol	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)
 ###########################################
 
-begin KEYWORD2
-check KEYWORD2
-ping  KEYWORD2
-sendData             KEYWORD2
-sendDataWithFeedback KEYWORD2
-broadcast  KEYWORD2
-sendUptime KEYWORD2
+begin	KEYWORD2
+check	KEYWORD2
+ping	KEYWORD2
+sendData	KEYWORD2
+sendDataWithFeedback	KEYWORD2
+broadcast	KEYWORD2
+sendUptime	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords